### PR TITLE
Fix a crash on handling distorted server version (like "VERSION 1.4.14 (Ubuntu)")

### DIFF
--- a/src/mcd.erl
+++ b/src/mcd.erl
@@ -750,7 +750,7 @@ data_receiver_loop(Parent, ParentMon, Socket) ->
 data_receiver_accept_response(rtVer, _, Socket) ->
 	{ok, Response} = gen_tcp:recv(Socket, 0),
 	case string:tokens(binary_to_list(Response), " \r\n") of
-		["VERSION", Value] -> {ok, Value};
+		["VERSION", Value | _] -> {ok, Value};
 		_ -> data_receiver_error_reason(Response)
 	end;
 data_receiver_accept_response(rtGet, ExpFlags, Socket) ->


### PR DESCRIPTION
When I tried to connect to memcached server on my Ubuntu 14.04 the mcd crashed. This happens because the memcached server returns distorted server version string - "VERSION 1.4.14 (Ubuntu)". The mcd doesn't expect any other tokens after a version number, so it crashes.
I propose to ignore such tokens.
