### PR TITLE
Fix usage of deprecated erlang:now/0

### DIFF
--- a/src/mcd.erl
+++ b/src/mcd.erl
@@ -1,4 +1,4 @@
-%%% 
+%%%
 %%% This module uses memcached protocol to interface memcached daemon:
 %%% http://code.sixapart.com/svn/memcached/trunk/server/doc/protocol.txt
 %%%
@@ -44,7 +44,7 @@
 %%%   Value: int()>=0
 %%%   Time: int()>=0
 %%%   Reason: noconn | notfound | notstored | overload | timeout | noproc | all_nodes_down
-%%% 
+%%%
 -module(mcd).
 -behavior(gen_server).
 
@@ -317,7 +317,7 @@ unload_connection(ServerRef) ->
 % gen_server callbacks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--record(state, { 
+-record(state, {
 	address, port = 11211, socket = nosocket,
 	receiver,		% data receiver process
 	requests = 0,		% client requests received
@@ -549,7 +549,7 @@ reconnect(#state{address = Address, port = Port, socket = OldSock} = State) ->
 
 	NewAnomalies = case is_atom(State#state.status) of
 		false -> State#state.anomalies;
-		true -> 
+		true ->
 			reportEvent(State, state, down),
 			incrAnomaly(State#state.anomalies, reconnects)
 	end,
@@ -563,7 +563,7 @@ compute_next_reconnect_delay(#state{status = Status}) ->
 	ComputeReconnectDelay = fun(Since) ->
 		% Wait increasingly longer,
 		% but no longer than 5 minutes.
-		case (utime(now()) - utime(Since)) of
+		case (utime(erlang:timestamp()) - utime(Since)) of
 			N when N > 300 -> 300 * 1000;
 			N -> N * 1000
 		end
@@ -572,7 +572,7 @@ compute_next_reconnect_delay(#state{status = Status}) ->
 		{connecting, Since, _} -> {Since, ComputeReconnectDelay(Since)};
 		{testing, Since} -> {Since, ComputeReconnectDelay(Since)};
 		{wait, Since} -> {Since, ComputeReconnectDelay(Since)};
-		_ -> {now(), 1000}
+		_ -> {erlang:timestamp(), 1000}
 	end.
 
 reconnector_process(MCDServerPid, Address, Port) ->
@@ -807,4 +807,3 @@ data_receiver_error_reason(<<"CLIENT_ERROR ", Reason/binary>>) ->
 
 data_receiver_error_reason(Code, Reason) ->
 	{error, {Code, [C || C <- binary_to_list(Reason), C >= $ ]}}.
-

--- a/src/mcd_parallel.erl
+++ b/src/mcd_parallel.erl
@@ -42,7 +42,7 @@
 get(Wants, Satisfier) -> get(Wants, Satisfier, 5000).
 get(Wants, Satisfier, Timeout) ->
     ProcessRef = make_ref(),
-    wait(ProcessRef, now(), Timeout, [begin
+    wait(ProcessRef, erlang:monotonic_time(), Timeout, [begin
         ItemRef = make_ref(),
         try
             ServerRef ! { '$gen_call', {self(), {ProcessRef, ItemRef}}, {get, Key} }
@@ -54,7 +54,8 @@ get(Wants, Satisfier, Timeout) ->
     end || {ServerRef, Key} <- Wants], Satisfier).
 
 wait(ProcessRef, Started, Timeout, Waiting, Satisfier) ->
-    WaitMore = case Timeout - (timer:now_diff(now(), Started) div 1000) of
+    Diff = erlang:convert_time_unit(erlang:monotonic_time() - Started, native, milli_seconds),
+    WaitMore = case Timeout - Diff of
         Time when Time > 0 ->
             Time;
         _ ->

--- a/src/mcd_test_helper.erl
+++ b/src/mcd_test_helper.erl
@@ -10,10 +10,10 @@
 ]).
 
 wait_connection(Pid) ->
-    wait_connection(Pid, now(), 5000).
+    wait_connection(Pid, erlang:timestamp(), 5000).
 
 wait_connection(Pid, Started, Timeout) ->
-    case {mcd:version(Pid), Timeout - (timer:now_diff(now(), Started) div 1000)} of
+    case {mcd:version(Pid), Timeout - (timer:now_diff(erlang:timestamp(), Started) div 1000)} of
         {{ok, [_ | _]}, _} ->
             ok;
         {Error, WaitMore} when WaitMore =< 0 ->

--- a/src/mcd_test_helper.erl
+++ b/src/mcd_test_helper.erl
@@ -10,10 +10,11 @@
 ]).
 
 wait_connection(Pid) ->
-    wait_connection(Pid, erlang:timestamp(), 5000).
+    wait_connection(Pid, erlang:monotonic_time(), 5000).
 
 wait_connection(Pid, Started, Timeout) ->
-    case {mcd:version(Pid), Timeout - (timer:now_diff(erlang:timestamp(), Started) div 1000)} of
+    Diff = erlang:convert_time_unit(erlang:monotonic_time() - Started, native, milli_seconds),
+    case {mcd:version(Pid), Timeout - Diff} of
         {{ok, [_ | _]}, _} ->
             ok;
         {Error, WaitMore} when WaitMore =< 0 ->


### PR DESCRIPTION
The previously widely used now/0 function has
been deprecated in favor of different functions
for specific tasks. These are things like creating
monotonically ordered integers, getting timestamps,
performing diffs on timestamps, etc.

Reference page for deprecation purpose:
http://www.erlang.org/doc/apps/erts/time_correction.html
